### PR TITLE
Use internal methods instead of service methods directly

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
-
 {
   "plugins": ["add-module-exports"],
   "presets": [ "es2015" ]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-feathers-nedb
-================
+# feathers-nedb
 
 [![Build Status](https://travis-ci.org/feathersjs/feathers-nedb.png?branch=master)](https://travis-ci.org/feathersjs/feathers-nedb)
 [![Code Climate](https://codeclimate.com/github/feathersjs/feathers-nedb.png)](https://codeclimate.com/github/feathersjs/feathers-nedb)
@@ -67,6 +66,10 @@ app.listen(port, function() {
 You can run this example by using `node examples/app` and going to [localhost:3030/todos](http://localhost:3030/todos). You should see an empty array. That's because you don't have any Todos yet but you now have full CRUD for your new todos service.
 
 ## Changelog
+
+__2.1.0__
+
+- Use internal methods instead of service methods directly
 
 __2.0.0__
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,3 @@
-import errors from 'feathers-errors';
-
 export function multiOptions(id, params) {
   let query = Object.assign({}, params.query);
   let options = Object.assign({ multi: true }, params.options);
@@ -10,16 +8,6 @@ export function multiOptions(id, params) {
   }
 
   return { query, options };
-}
-
-export function mapItems(id) {
-  return function(items) {
-    if(!items.length) {
-      throw new errors.NotFound(`No record found for id '${id}'`);
-    }
-
-    return items.length === 1 ? items[0] : items;
-  };
 }
 
 export function getSelect(select) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,13 +20,13 @@ let counter = 0;
 const filename = path.join('db-data', 'people');
 const db = new NeDB({ filename, autoload: true });
 const nedbService = service({ Model: db }).extend({
-  find(params) {
+  _find(params) {
     params.query = params.query || {};
     if(!params.query.$sort) {
       params.query.$sort = { counter: 1 };
     }
 
-    return this._super(params);
+    return this._super.apply(this, arguments);
   },
 
   create(data, params) {


### PR DESCRIPTION
This is for https://github.com/feathersjs/feathers/issues/218. Basically, if an adapter uses its own service methods internally (like doing a `get` after removing an item) they can't be the original service methods (like `get`, `create`, `find` etc.) directly since those can be modified by Feathers with mixins and hooks and we do not want those to run in that case.

For this adapter we now provide an internal `_get` (also see #7), `_find` (that ignores pagination) and `_getOrFind` (for patch and remove many). Also adds an option to skip counting the items.