### PR TITLE
fix errors in update and patch with custom id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,6 +110,7 @@ class Service {
 
     // We can not update the id
     delete data[this.id];
+    delete data._id;
 
     // Run the query
     return nfcall(this.Model, 'update', query, { $set: data }, options)
@@ -124,7 +125,8 @@ class Service {
     let { query, options } = multiOptions(id, this.id, params);
 
     // We can not update the id
-    delete data[this.id];
+    data[this.id] = id;
+    delete data._id;
 
     return nfcall(this.Model, 'update', query, data, options)
       .then(() => this._findOrGet(id));


### PR DESCRIPTION
@ekryski 
Oh sorry I was very sleepy yesterday :sleepy:

PR fixs two problems:

1. If we remove custom id from the data then `update` will remove it from database (behavior in current realization). So we need to set custom id to old value in the input data to make it read only. It is need for future `_findOrGet()` call.

2. If data contains `_id` field different from current then nedb will throw exception (`_id` is read only). So we need to remove it from input data.