### PR TITLE
Modifiers can be enabled with params

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -135,7 +135,7 @@ class Service {
   }
 
   patch (id, data, params) {
-    const { query, options } = multiOptions(id, this.id, params);
+    const { query, options, modifier } = multiOptions(id, this.id, params);
     const mapIds = page => page.data.map(current => current[this.id]);
 
     // By default we will just query for the one id. For multi patch
@@ -155,9 +155,9 @@ class Service {
           }
         });
 
-        return nfcall(this.Model, 'update', query, {
-          $set: omit(data, this.id, '_id')
-        }, options)
+        const entry = modifier ? omit(data, this.id, '_id') : { $set: omit(data, this.id, '_id') };
+
+        return nfcall(this.Model, 'update', query, entry, options)
         .then(() => this._findOrGet(id, findParams));
       })
       .then(select(params, this.id));

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,13 +3,14 @@ import filter from 'feathers-query-filters';
 export function multiOptions (id, idField, params) {
   let query = filter(params.query || {}).query;
   let options = Object.assign({ multi: true }, params.nedb || params.options);
+  let modifier = params.modifier || false;
 
   if (id !== null) {
     options.multi = false;
     query[idField] = id;
   }
 
-  return { query, options };
+  return { query, options, modifier };
 }
 
 export function getSelect (select) {


### PR DESCRIPTION
### Summary

NeDB provides different modifiers for updating like `$set`, `$unset`, `$inc`, `$min`, `$max`, `$push`, `$pop`, `$addToSet`, ... Those additional modifiers are extremely useful for example patching arrays.

- [x] Tell us about the problem your pull request is solving.
`It allows to enable the usage of modifiers by passing a variable to` params `, which makes it possible to use the above mentioned modifiers. It keeps` $set `as the default operation like previously.`
- [x] Are there any open issues that are related to this?
`No`
- [x] Is this PR dependent on PRs in other repos?
`No`

### Discussion

Alternatively a `query` parameter could be used to enable this option, however in my opinion this should be enabled by the server explicitly, rather than giving the client the option to enable it where it wants.